### PR TITLE
Accept headers for produce

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -109,7 +109,7 @@ module Kafka
     # @param retries [Integer] the number of times to retry the delivery before giving
     #   up.
     # @return [nil]
-    def deliver_message(value, key: nil, topic:, partition: nil, partition_key: nil, retries: 1)
+    def deliver_message(value, key: nil, topic:, partition: nil, partition_key: nil, retries: 1, headers: {})
       create_time = Time.now
 
       message = PendingMessage.new(
@@ -119,6 +119,7 @@ module Kafka
         partition,
         partition_key,
         create_time,
+        headers,
       )
 
       if partition.nil?

--- a/lib/kafka/fetched_message.rb
+++ b/lib/kafka/fetched_message.rb
@@ -36,5 +36,10 @@ module Kafka
     def is_control_record
       @message.is_control_record
     end
+
+    # @return [Hash] the headers of this message
+    def headers
+      @message.headers
+    end
   end
 end

--- a/lib/kafka/message_buffer.rb
+++ b/lib/kafka/message_buffer.rb
@@ -14,8 +14,8 @@ module Kafka
       @bytesize = 0
     end
 
-    def write(value:, key:, topic:, partition:, create_time: Time.now)
-      message = Protocol::Record.new(key: key, value: value, create_time: create_time)
+    def write(value:, key:, topic:, partition:, create_time: Time.now, headers:)
+      message = Protocol::Record.new(key: key, value: value, create_time: create_time, headers: headers)
 
       buffer_for(topic, partition) << message
 

--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -1,14 +1,15 @@
 module Kafka
   class PendingMessage
-    attr_reader :value, :key, :topic, :partition, :partition_key, :create_time, :bytesize
+    attr_reader :value, :key, :topic, :partition, :partition_key, :create_time, :bytesize, :headers
 
-    def initialize(value, key, topic, partition, partition_key, create_time)
+    def initialize(value, key, topic, partition, partition_key, create_time, headers)
       @value = value
       @key = key
       @topic = topic
       @partition = partition
       @partition_key = partition_key
       @create_time = create_time
+      @headers = headers
       @bytesize = key.to_s.bytesize + value.to_s.bytesize
     end
 

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -177,7 +177,7 @@ module Kafka
     #
     # @raise [BufferOverflow] if the maximum buffer size has been reached.
     # @return [nil]
-    def produce(value, key: nil, topic:, partition: nil, partition_key: nil, create_time: Time.now)
+    def produce(value, key: nil, topic:, partition: nil, partition_key: nil, create_time: Time.now, headers: nil)
       message = PendingMessage.new(
         value && value.to_s,
         key && key.to_s,
@@ -185,6 +185,7 @@ module Kafka
         partition && Integer(partition),
         partition_key && partition_key.to_s,
         create_time,
+        headers && headers
       )
 
       if buffer_size >= @max_buffer_size
@@ -205,6 +206,7 @@ module Kafka
         key: key,
         topic: topic,
         create_time: create_time,
+        headers: headers,
         message_size: message.bytesize,
         buffer_size: buffer_size,
         max_buffer_size: @max_buffer_size,
@@ -355,6 +357,7 @@ module Kafka
             topic: message.topic,
             partition: partition,
             create_time: message.create_time,
+            headers: message.headers,
           )
         rescue Kafka::Error => e
           @instrumenter.instrument("topic_error.producer", {
@@ -393,7 +396,8 @@ module Kafka
             topic,
             partition,
             nil,
-            message.create_time
+            message.create_time,
+            message.headers
           )
         end
       end


### PR DESCRIPTION
While preparing Phobos producers for 0.11 message format and toying with your branch, we found we needed to change the following in ruby-kafka which might be of value for your PR.

Phobos work is tracked in
- https://github.com/klarna/phobos/pull/77